### PR TITLE
feat(overlay): Add utilities for OpenAPI schema manipulation

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,6 +11,7 @@
         metosin/jsonista {:mvn/version "0.3.13"}
         exoscale/ex {:mvn/version "0.4.1"}
         com.networknt/json-schema-validator {:mvn/version "1.5.9"}
+        com.jayway.jsonpath/json-path {:mvn/version "2.9.0"}
         ring/ring-core {:mvn/version "1.15.3"}}
  :aliases
  {:test

--- a/src/s_exp/legba/overlay.clj
+++ b/src/s_exp/legba/overlay.clj
@@ -1,0 +1,94 @@
+(ns s-exp.legba.overlay
+  "Provides overlay manipulation utilities for OpenAPI schemas, enabling dynamic
+  updates or removals on schema documents using OpenAPI Overlay instructions.
+https://spec.openapis.org/overlay/latest.html  "
+  (:require [jsonista.core :as json])
+  (:refer-clojure :exclude [update apply])
+  (:import (com.jayway.jsonpath Configuration
+                                DocumentContext
+                                JsonPath
+                                Option
+                                PathNotFoundException
+                                Predicate)))
+
+(set! *warn-on-reflection* true)
+
+(def ^Configuration conf
+  (doto (Configuration/defaultConfiguration)
+    (.addOptions (into-array Option [Option/DEFAULT_PATH_LEAF_TO_NULL
+                                     Option/SUPPRESS_EXCEPTIONS]))))
+
+(def ^:private preds (into-array Predicate []))
+
+(defn- apply-update
+  "Apply an update to the OpenAPI schema at the given target path.
+
+  Parameters:
+  - openapi: The OpenAPI schema data structure (map)
+  - target: JSONPath expression indicating where the update applies
+  - update: The value to set at the target path
+
+  Returns the updated OpenAPI schema."
+  [^DocumentContext openapi ^String target update]
+  (try
+    (.set openapi (JsonPath/compile target preds) update)
+    (catch PathNotFoundException _e
+      openapi)))
+
+(defn- apply-remove
+  "Remove data from the OpenAPI schema at the given target path.
+
+  Parameters:
+  - openapi: The OpenAPI schema data structure (map)
+  - target: JSONPath expression indicating where the remove applies
+  - remove: Boolean; if true, excise data at the target path
+
+  Returns the updated OpenAPI schema."
+  [^DocumentContext openapi ^String target remove]
+  (try
+    (cond-> openapi
+      remove
+      (.delete (JsonPath/compile target preds)))
+    (catch PathNotFoundException _e
+      openapi)))
+
+(defn apply
+  "Apply overlay actions (update/remove) to the given OpenAPI schema string.
+
+  Parameters:
+  - openapi-string: String, JSON representation of the OpenAPI schema
+  - overlay-string: String, JSON representation of the overlay instructions
+
+  Returns the OpenAPI schema with all overlay actions applied as String"
+  [^String openapi-string overlay-string]
+  (let [overlay (json/read-value overlay-string)
+        openapi (JsonPath/parse openapi-string)]
+    (.jsonString ^DocumentContext
+     (reduce (fn [openapi {:as _action :strs [target remove update]}]
+               (cond-> openapi
+                 update
+                 (apply-update target update)
+                 remove
+                 (apply-remove target remove)))
+             openapi
+             (get overlay "actions")))))
+
+;; (def doc
+;;   "String containing contents of OpenAPI schema from store.json resource."
+;;   (slurp (io/resource "schema.json")))
+
+;; (def overlay "{
+;;   \"overlay\": \"1.0.0\",
+;;   \"info\": {
+;;     \"title\": \"Targeted Overlay\",
+;;     \"version\": \"1.0.0\"
+;;   },
+;;   \"actions\": [
+;;     {
+;;       \"target\": \"$..['x-private']\",
+;;       \"remove\": true
+;;     }
+;;   ]
+;; }")
+
+;; (apply doc overlay)

--- a/test/resources/schema/oas/3.1/store.json
+++ b/test/resources/schema/oas/3.1/store.json
@@ -18,6 +18,7 @@
     "paths": {
         "/search": {
             "get": {
+                "x-exo-private": true,
                 "summary": "Searches a list of items",
                 "description": "Search",
                 "parameters": [


### PR DESCRIPTION
Introduce `s-exp.legba.overlay` namespace for applying dynamic updates and removals to OpenAPI schemas using overlay instructions. Includes functions for handling JSONPath expressions and integrating external dependency
`com.jayway.jsonpath/json-path`. Added initial usage documentation with examples.

build: Add `com.jayway.jsonpath/json-path` to project dependencies

Updated the `deps.edn` to include the `json-path` library (version 2.9.0) for JSONPath manipulations required by the overlay functionality.

ref #13